### PR TITLE
Fix: closeOnSelect not working when item is already selected.

### DIFF
--- a/ux/slidenavigation/View.js
+++ b/ux/slidenavigation/View.js
@@ -388,11 +388,22 @@ Ext.define('Ext.ux.slidenavigation.View', {
             }
         });
     },
+
+    /**
+     * @private
+     *
+     * Always called when item in the list is tapped.
+     */
+    onItemTap: function (list, index, target, item, e, eOpts) {
+        if (list.isSelected(item) && this.config.closeOnSelect) {
+            this.closeContainer();
+        }
+    },
     
     /**
      *  @private
      *
-     *  Called when an item in the list is tapped.
+     *  Called when an item in the list is tapped if item is not selected.
      */
     onSelect: function(list, item, eOpts) {
         var me = this,
@@ -686,6 +697,7 @@ Ext.define('Ext.ux.slidenavigation.View', {
                    'z-index: 2',
             listeners: {
                 select: this.onSelect,
+                itemtap: this.onItemTap,
                 scope: this
             }
         }));


### PR DESCRIPTION
When closeOnSelect property is true and select item, slide menu is close. But the tapped item is already selected, this feature is not working well. Because Ext.dataview.List component does not fire 'select' event when tapped item is already selected.  

To solve this, I add 'itemtap' event handler to navigation item list to close navigation, only tapped item is selected.
